### PR TITLE
Fix: Notenrechner table layout with new PO

### DIFF
--- a/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/js/grade_calculator.js
+++ b/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/js/grade_calculator.js
@@ -76,12 +76,10 @@ document.addEventListener('DOMContentLoaded', function() {
 				physics : "From the modules <i>Physics&#160;I–III</i>, only the best two grades are included in the total grade, with a weight of 11&#160;% each.",
 				math : "Only the best grade from the modules <i>Fundamental Mathematics</i> and <i>Integration Theory</i> enters the total grade with a weight of 11&#160;%. (<i>Math for Physicists&#160;I</i> is not an “exam” according to the regulations, so it counts with 0&#160;%.)",
 				minor : "The grade for the module <i>Interdisciplinary Studies</i> is formed, depending on the subject, as described in the <a href=\"/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html\" class=\"ext\" target=\"_blank\">exam regulations</a>. (The weights for the individual exams have to be entered manually. E.&#160;g. in the case of <i>Computer Science</i>: 50–50.)",
-				lab_course : "The <i>Laboratory Course&#160;I</i> does not enter into the total grade."
 			},
 			20210412 : {
 				physics : "From the modules <i>Physik&nbsp;I–II</i> only the best two grades are included in the total grade, with a wieght of 10&nbsp;% each.",
 				math : "",
-				lab_course : "",
 				minor : "The grade for the module <i>Interdisciplinary Studies</i> is formed, depending on the subject, as described in the <a href=\"/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html\" class=\"ext\" target=\"_blank\">exam regulations</a>. (The weights for the individual exams have to be entered manually. E.&#160;g. in the case of <i>Computer Science</i>: 50–50.)",
 			}
 		}

--- a/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_de.html
+++ b/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_de.html
@@ -101,7 +101,7 @@
       <td><label for=fsphys_gc_lab_course_1>Experimentelle Übungen&nbsp;I/Physikalisches Grundpraktikum</label></td>
       <td><input id=fsphys_gc_lab_course_1 type=number min=1 max=4 step=0.1 value=4></td>
       <td id=fsphys_gc_lab_course_1_weight class=fsphys_gc_weight>9</td>
-      <td id=fsphys_gc_lab_course_hint rowspan="2"></td>
+      <td></td>
     </tr>
     <tr>
       <td><label for=fsphys_gc_lab_course_2>Experimentelle Übungen&nbsp;II/Physikalisches Praktikum für Fortgeschrittene</label></td>

--- a/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_en.html
+++ b/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_en.html
@@ -101,7 +101,7 @@
       <td><label for=fsphys_gc_lab_course_1>Laboratory Course&#160;I</label></td>
       <td><input id=fsphys_gc_lab_course_1 type=number min=1 max=4 step=0.1 value=4></td>
       <td id=fsphys_gc_lab_course_1_weight class=fsphys_gc_weight>9</td>
-      <td id=fsphys_gc_lab_course_hint rowspan="2">The <i>Laboratory Course&#160;I</i> does not enter into the total grade.</td>
+      <td></td>
     </tr>
     <tr>
       <td><label for="fsphys_gc_lab_course_2">Laboratory Course&#160;II</label></td>


### PR DESCRIPTION
With my last PR, entries are hidden that are not relevant in the given PO.
This introduced an issue with the table layout that is hereby fixed.

Also, the code for showing a hint about an irrelevant grade is removed since
that grade is not shown any longer anyways.