### PR TITLE
Notenrechner mit dynamsicher Gewichtung

### DIFF
--- a/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/js/grade_calculator.js
+++ b/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/js/grade_calculator.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', function() {
 				lab_course : "The <i>Laboratory Course&#160;I</i> does not enter into the total grade."
 			},
 			20210412 : {
-				physics : "From the modules <i>Physik&nbsp;I–II</i> only the best two grades are included in the total grade, with a wieght of 10&nbsp;% each.",
+				physics : "From the modules <i>Physik&nbsp;I–II</i> only the best grade is included in the total grade, with a weight of 10&nbsp;% each.",
 				math : "",
 				lab_course : "",
 				minor : "The grade for the module <i>Interdisciplinary Studies</i> is formed, depending on the subject, as described in the <a href=\"/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html\" class=\"ext\" target=\"_blank\">exam regulations</a>. (The weights for the individual exams have to be entered manually. E.&#160;g. in the case of <i>Computer Science</i>: 50–50.)",
@@ -158,7 +158,11 @@ document.addEventListener('DOMContentLoaded', function() {
 				return {exam: key, grade: user_input[key]};
 			});
 			grades.sort(function(a, b) {
-				return a.grade - b.grade;
+				var sc = 1
+				// grades with values 0 are to be weight less than actual grades
+				if(a.grade===0 || b.grade ===0)
+					sc = -1
+				return (a.grade - b.grade)*sc;
 			});
 			var weights_set = {};
 			grades.forEach(function(el, idx) {
@@ -224,24 +228,37 @@ document.addEventListener('DOMContentLoaded', function() {
 		var weights = exams.weights;
 		// minor grade
 		var minor_grade = 0;
+		var minor_weight_sum = 0;
 		for (var exam in weights) {
 			// build minor grade from values starting with 'minor_'
 			if (exam.indexOf('minor_') === 0) {
 				minor_grade += user_input[exam] * weights[exam];
+				if(user_input[exam] != 0)
+					minor_weight_sum +=weights[exam];
 			}
 		}
-		minor_grade /= 100;
+		if(minor_weight_sum != 0)
+			minor_grade /= minor_weight_sum;
+		else
+			minor_grade = 0
 		user_input.minor = minor_grade;
 		minor_grade = minor_grade.toLocaleString(FSPHYS_LOCALE,
 			{minimumFractionDigits: 2, maximumFractionDigits: 2});
 		// total grade
 		total_grade = 0;
+		var total_weight_sum =0;
 		for (var exam in weights) {
 			if (exam.indexOf('minor_') !== 0 && user_input[exam] !== undefined) {
 				total_grade += user_input[exam] * weights[exam];
+				if(user_input[exam] != 0)
+					total_weight_sum += weights[exam];
 			}
 		}
-		total_grade = (total_grade / 100).toLocaleString(FSPHYS_LOCALE,
+		if(total_weight_sum != 0)
+			total_grade = (total_grade / total_weight_sum)
+		else
+			total_grade = 0	
+		total_grade = total_grade.toLocaleString(FSPHYS_LOCALE,
 			{minimumFractionDigits: 2, maximumFractionDigits: 2});
 		// write (possibly updated) weight information to DOM
 		for (var exam in exams.weights) {

--- a/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_de.html
+++ b/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_de.html
@@ -1,131 +1,165 @@
-<h2>Berechnung der Durchschnittsnote im <abbr title="Bachelor of Science">B.&#160;Sc.</abbr> Physik an der <abbr title="Westfälischen Wilhelms-Universität">WWU</abbr> Münster</h2>
-<noscript><p class="fsphys_error"><strong>Zur Verwendung des Notenrechners muss im Browser <a href="https://de.wikipedia.org/wiki/JavaScript" class="ext" target="_blank">JavaScript</a> aktiviert sein! Ohne JavaScript können leider keine Berechnungen durchgeführt werden.</strong></p></noscript>
-<p>Mit diesem kleinen Tool kann die endgültige Durchschnittsnote im Bachelor berechnet werden. Dafür muss lediglich für jedes Modul entsprechend eine Note eingetragen werden. Falls diese noch nicht feststeht, muss eine erwartete Note angegeben werden.</p>
+<h2>Berechnung der Durchschnittsnote im <abbr title="Bachelor of Science">B.&#160;Sc.</abbr> Physik an der <abbr
+    title="Westfälischen Wilhelms-Universität">WWU</abbr> Münster</h2>
+<noscript>
+  <p class="fsphys_error"><strong>Zur Verwendung des Notenrechners muss im Browser <a
+        href="https://de.wikipedia.org/wiki/JavaScript" class="ext" target="_blank">JavaScript</a> aktiviert sein! Ohne
+      JavaScript können leider keine Berechnungen durchgeführt werden.</strong></p>
+</noscript>
+<p>Mit diesem kleinen Tool kann die endgültige Durchschnittsnote im Bachelor berechnet werden. Dafür muss lediglich für
+  jedes Modul entsprechend eine Note eingetragen werden. Falls diese noch nicht feststeht, muss eine erwartete Note
+  angegeben werden.</p>
 <div id="fsphys_gc_form">
-<p><small>Version: <span id="fsphys_gc_version">2021-05-27</span></small></p>
-<p>PO-Version: 
-	<select id="fsphys_gc_er_version">
-		<option value=20161117 >Ab WS 2016/2017</option>
-		<option value=20210412 >Ab WS 2020/2021</option>
-  </select>
-</p>
-<table>
-  <colgroup><col style="width: 35%;" /><col /><col /><col style="width: 35%;" /></colgroup>
-  <thead>
-    <tr>
-      <th scope="col">Modul</th>
-      <th scope="col">Note</th>
-      <th scope="col">Gewichtung nach <a href="/Physik/Studieren/Studiengaenge/InfoPhBSc.html" class="ext" target="_blank"><abbr title="Prüfungsordnung">PO</abbr></a>&#160;(%)</th>
-      <th scope="col">Hinweise</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><label for="fsphys_gc_physics_1">Physik&#160;I</label></td>
-      <td><input id="fsphys_gc_physics_1" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_physics_1_weight" class="fsphys_gc_weight">11</td>
-      <td id=fsphys_gc_physics_hint rowspan="3">Aus den Modulen <i>Physik&#160;I–III</i> werden nur die zwei besten Noten mit einer Gewichtung von jeweils 11&#160;% in die Gesamtnote mit einbezogen.</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_physics_2">Physik&#160;II</label></td>
-      <td><input id="fsphys_gc_physics_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_physics_2_weight" class="fsphys_gc_weight">11</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_physics_3">Physik&#160;III</label></td>
-      <td><input id="fsphys_gc_physics_3" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_physics_3_weight" class="fsphys_gc_weight">0</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_math_2">Mathematische Grundlagen<br />
-      (Mathe für Physiker&#160;II)</label></td>
-      <td><input id="fsphys_gc_math_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_math_2_weight" class="fsphys_gc_weight">11</td>
-      <td id=fsphys_gc_math_hint rowspan="2">Nur die bessere Note der Module <i>Mathematische Grundlagen</i> und <i>Integrationstheorie</i> geht mit 11&#160;% in die Gesamtnote ein. (<i>Mathe für Physiker&#160;I</i> ist eine Studienleistung, hat also 0&#160;%.)</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_math_3">Integrationstheorie<br />
-      (Mathe für Physiker&#160;III)</label></td>
-      <td><input id="fsphys_gc_math_3" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_math_3_weight" class="fsphys_gc_weight">0</td>
-    </tr>
-    <tr>
-      <td colspan="3">Fachübergreifende Studien</td>
-      <td id=fsphys_gc_minor_hint rowspan="5">Bei dem Modul <i>Fachübergreifende Studien</i> wird die Gesamtnote je nach Beschreibung in der <a href="/Physik/Studieren/Studiengaenge/InfoPhBSc.html" class="ext" target="_blank">Prüfungsordnung</a> gebildet. (Die Gewichtungen für die einzelnen Prüfungsleistungen müssen eigenhändig eingetragen werden. Z.&#160;B. im Fall <i>Informatik</i>: 50–50.)</td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td><label for="fsphys_gc_minor_1">Prüfungsleistung&#160;1</label></td>
-      <td><input id="fsphys_gc_minor_1" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_1_weight" min="0" max="100" value="50" type="number" /></td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td><label for="fsphys_gc_minor_2">Prüfungsleistung&#160;2</label></td>
-      <td><input id="fsphys_gc_minor_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_2_weight" min="0" max="100" value="50" type="number" /></td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td><label for="fsphys_gc_minor_3">Prüfungsleistung&#160;3</label></td>
-      <td><input id="fsphys_gc_minor_3" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_3_weight" min="0" max="100" value="0" type="number" /></td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td>Gesamtnote Nebenfach</td>
-      <td><output id="fsphys_gc_minor" for="fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight">4,00</output></td>
-      <td id="fsphys_gc_minor_weight" class="fsphys_gc_weight">12</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_quantum_mechanics">Atom- und Quantenphysik</label></td>
-      <td><input id="fsphys_gc_quantum_mechanics" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_quantum_mechanics_weight" class="fsphys_gc_weight">7</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_signal_processing">Messtechnik und Signalverarbeitung</label></td>
-      <td><input id="fsphys_gc_signal_processing" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_signal_processing_weight" class="fsphys_gc_weight">7</td>
-      <td></td>
-    </tr>
-    <tr>
+  <p><small>Version: <span id="fsphys_gc_version">2021-05-27</span></small></p>
+  <p>PO-Version:
+    <select id="fsphys_gc_er_version">
+      <option value=20161117>Ab WS 2016/2017</option>
+      <option value=20210412>Ab WS 2020/2021</option>
+    </select>
+  </p>
+  <table>
+    <colgroup>
+      <col style="width: 35%;" />
+      <col />
+      <col />
+      <col style="width: 35%;" />
+    </colgroup>
+    <thead>
+      <tr>
+        <th scope="col">Modul</th>
+        <th scope="col">Note</th>
+        <th scope="col">Gewichtung nach <a href="/Physik/Studieren/Studiengaenge/InfoPhBSc.html" class="ext"
+            target="_blank"><abbr title="Prüfungsordnung">PO</abbr></a>&#160;(%)</th>
+        <th scope="col">Hinweise</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><label for="fsphys_gc_physics_1">Physik&#160;I</label></td>
+        <td><input id="fsphys_gc_physics_1" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_physics_1_weight" class="fsphys_gc_weight">11</td>
+        <td id=fsphys_gc_physics_hint rowspan="3">Aus den Modulen <i>Physik&#160;I–III</i> werden nur die zwei besten
+          Noten mit einer Gewichtung von jeweils 11&#160;% in die Gesamtnote mit einbezogen.</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_physics_2">Physik&#160;II</label></td>
+        <td><input id="fsphys_gc_physics_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_physics_2_weight" class="fsphys_gc_weight">11</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_physics_3">Physik&#160;III</label></td>
+        <td><input id="fsphys_gc_physics_3" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_physics_3_weight" class="fsphys_gc_weight">0</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_math_2">Mathematische Grundlagen<br />
+            (Mathe für Physiker&#160;II)</label></td>
+        <td><input id="fsphys_gc_math_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_math_2_weight" class="fsphys_gc_weight">11</td>
+        <td id=fsphys_gc_math_hint rowspan="2">Nur die bessere Note der Module <i>Mathematische Grundlagen</i> und
+          <i>Integrationstheorie</i> geht mit 11&#160;% in die Gesamtnote ein. (<i>Mathe für Physiker&#160;I</i> ist
+          eine Studienleistung, hat also 0&#160;%.)</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_math_3">Integrationstheorie<br />
+            (Mathe für Physiker&#160;III)</label></td>
+        <td><input id="fsphys_gc_math_3" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_math_3_weight" class="fsphys_gc_weight">0</td>
+      </tr>
+      <tr>
+        <td colspan="3">Fachübergreifende Studien</td>
+        <td id=fsphys_gc_minor_hint rowspan="5">Bei dem Modul <i>Fachübergreifende Studien</i> wird die Gesamtnote je
+          nach Beschreibung in der <a href="/Physik/Studieren/Studiengaenge/InfoPhBSc.html" class="ext"
+            target="_blank">Prüfungsordnung</a> gebildet. (Die Gewichtungen für die einzelnen Prüfungsleistungen müssen
+          eigenhändig eingetragen werden. Z.&#160;B. im Fall <i>Informatik</i>: 50–50.)</td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td><label for="fsphys_gc_minor_1">Prüfungsleistung&#160;1</label></td>
+        <td><input id="fsphys_gc_minor_1" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_1_weight" min="0" max="100" value="50" type="number" />
+        </td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td><label for="fsphys_gc_minor_2">Prüfungsleistung&#160;2</label></td>
+        <td><input id="fsphys_gc_minor_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_2_weight" min="0" max="100" value="50" type="number" />
+        </td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td><label for="fsphys_gc_minor_3">Prüfungsleistung&#160;3</label></td>
+        <td><input id="fsphys_gc_minor_3" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_3_weight" min="0" max="100" value="0" type="number" />
+        </td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td>Gesamtnote Nebenfach</td>
+        <td><output id="fsphys_gc_minor"
+            for="fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight">4,00</output>
+        </td>
+        <td id="fsphys_gc_minor_weight" class="fsphys_gc_weight">12</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_quantum_mechanics">Atom- und Quantenphysik</label></td>
+        <td><input id="fsphys_gc_quantum_mechanics" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_quantum_mechanics_weight" class="fsphys_gc_weight">7</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_signal_processing">Messtechnik und Signalverarbeitung</label></td>
+        <td><input id="fsphys_gc_signal_processing" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_signal_processing_weight" class="fsphys_gc_weight">7</td>
+        <td></td>
+      </tr>
+      <tr>
         <td><label for=fsphys_gc_computational_physics>Computational Physics</label></td>
         <td><input id=fsphys_gc_computational_physics type=number min=1 max=4 step=0.1 value=4></td>
         <td id=fsphys_gc_computational_physics_weight class=fsphys_gc_weight>7</td>
         <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_structure_of_matter">Struktur der Materie</label></td>
-      <td><input id="fsphys_gc_structure_of_matter" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_structure_of_matter_weight" class="fsphys_gc_weight">12</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for=fsphys_gc_lab_course_1>Experimentelle Übungen&nbsp;I/Physikalisches Grundpraktikum</label></td>
-      <td><input id=fsphys_gc_lab_course_1 type=number min=1 max=4 step=0.1 value=4></td>
-      <td id=fsphys_gc_lab_course_1_weight class=fsphys_gc_weight>9</td>
-      <td id=fsphys_gc_lab_course_hint rowspan="2"></td>
-    </tr>
-    <tr>
-      <td><label for=fsphys_gc_lab_course_2>Experimentelle Übungen&nbsp;II/Physikalisches Praktikum für Fortgeschrittene</label></td>
-      <td><input id="fsphys_gc_lab_course_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_lab_course_2_weight" class="fsphys_gc_weight">9</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_statistical_physics">Quantentheorie und Statistische Physik</label></td>
-      <td><input id="fsphys_gc_statistical_physics" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_statistical_physics_weight" class="fsphys_gc_weight">10</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_bachelor_thesis">Examensmodul<br />
-      (Bachelor-Arbeit)</label></td>
-      <td><input id="fsphys_gc_bachelor_thesis" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_bachelor_thesis_weight" class="fsphys_gc_weight">10</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
-<p style="font-size: larger;"><strong>Gesamtnote Bachelor:&#160;<output id="fsphys_gc_total" for="fsphys_gc_physics_1 fsphys_gc_physics_2 fsphys_gc_physics_3 fsphys_gc_math_2 fsphys_gc_math_3 fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight fsphys_gc_quantum_mechanics fsphys_gc_signal_processing fsphys_gc_structure_of_matter fsphys_gc_lab_course_2 fsphys_gc_statistical_physics fsphys_gc_bachelor_thesis">4,00</output></strong></p>
-<p>Mit einem Klick auf den folgenden Knopf könnt ihr eure derzeitig eingegebenen Daten in der <a href="https://de.wikipedia.org/wiki/Uniform_Resource_Locator" class="ext" target="_blank">URL</a> „speichern“. Um die Daten später wieder laden zu können, müsst ihr die URL irgendwo sichern – ihr könnt z.&#160;B. nach Drücken des Knopfs ein Lesezeichen setzen.</p>
-<p><small>Hier noch einmal der Hinweis, dass sämtliche Daten auf eurem Gerät verbleiben. Die Daten werden im <a href="https://de.wikipedia.org/wiki/Fragmentbezeichner" class="ext" target="_blank">URL-Fragment</a> gespeichert, welches vom Browser nie an die aufgerufene Webseite übertragen wird.</small></p>
-<button id="fsphys_gc_save">Daten speichern (⇒ Lesezeichen kann danach gesetzt werden!)</button></div>
-<script type="text/javascript">let FSPHYS_LOCALE = 'de-DE';</script> <script type="text/javascript" src="/Physik.FSPHYS/js/grade_calculator.js"></script>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_structure_of_matter">Struktur der Materie</label></td>
+        <td><input id="fsphys_gc_structure_of_matter" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_structure_of_matter_weight" class="fsphys_gc_weight">12</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for=fsphys_gc_lab_course_1>Experimentelle Übungen&nbsp;I/Physikalisches Grundpraktikum</label></td>
+        <td><input id=fsphys_gc_lab_course_1 type=number min=1 max=4 step=0.1 value=4></td>
+        <td id=fsphys_gc_lab_course_1_weight class=fsphys_gc_weight>9</td>
+        <td id=fsphys_gc_lab_course_hint rowspan="2"></td>
+      </tr>
+      <tr>
+        <td><label for=fsphys_gc_lab_course_2>Experimentelle Übungen&nbsp;II/Physikalisches Praktikum für
+            Fortgeschrittene</label></td>
+        <td><input id="fsphys_gc_lab_course_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_lab_course_2_weight" class="fsphys_gc_weight">9</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_statistical_physics">Quantentheorie und Statistische Physik</label></td>
+        <td><input id="fsphys_gc_statistical_physics" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_statistical_physics_weight" class="fsphys_gc_weight">10</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_bachelor_thesis">Examensmodul<br />
+            (Bachelor-Arbeit)</label></td>
+        <td><input id="fsphys_gc_bachelor_thesis" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_bachelor_thesis_weight" class="fsphys_gc_weight">10</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <p style="font-size: larger;"><strong>Gesamtnote Bachelor:&#160;<output id="fsphys_gc_total"
+        for="fsphys_gc_physics_1 fsphys_gc_physics_2 fsphys_gc_physics_3 fsphys_gc_math_2 fsphys_gc_math_3 fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight fsphys_gc_quantum_mechanics fsphys_gc_signal_processing fsphys_gc_structure_of_matter fsphys_gc_lab_course_2 fsphys_gc_statistical_physics fsphys_gc_bachelor_thesis">4,00</output></strong>
+  </p>
+  <p>Mit einem Klick auf den folgenden Knopf könnt ihr eure derzeitig eingegebenen Daten in der <a
+      href="https://de.wikipedia.org/wiki/Uniform_Resource_Locator" class="ext" target="_blank">URL</a> „speichern“. Um
+    die Daten später wieder laden zu können, müsst ihr die URL irgendwo sichern – ihr könnt z.&#160;B. nach Drücken des
+    Knopfs ein Lesezeichen setzen.</p>
+  <p><small>Hier noch einmal der Hinweis, dass sämtliche Daten auf eurem Gerät verbleiben. Die Daten werden im <a
+        href="https://de.wikipedia.org/wiki/Fragmentbezeichner" class="ext" target="_blank">URL-Fragment</a>
+      gespeichert, welches vom Browser nie an die aufgerufene Webseite übertragen wird.</small></p>
+  <button id="fsphys_gc_save">Daten speichern (⇒ Lesezeichen kann danach gesetzt werden!)</button>
+</div>
+<script type="text/javascript">let FSPHYS_LOCALE = 'de-DE';</script>
+<script type="text/javascript" src="/Physik.FSPHYS/js/grade_calculator.js"></script>

--- a/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_en.html
+++ b/www/data/Physik.FSPHYS/imperialive/Physik.FSPHYS/studieren/notenrechner_snippet_en.html
@@ -1,130 +1,163 @@
-<h2>Calculating the average grade in the <abbr title="Bachelor of Science">B.&#160;Sc.</abbr> Physics program at <abbr title="Westfälische Wilhelms-Universität">WWU</abbr> Münster</h2>
-<noscript><p class="fsphys_error"><strong><a href="https://en.wikipedia.org/wiki/JavaScript" class="ext" target="_blank">JavaScript</a> must be activated in your browser in order to use the grade calculator! Unfortunately, no calculations can be executed without JavaScript.</strong></p></noscript>
-<p>With this little tool, the final average grade for the bachelor’s program can be calculated. This can be done by simply entering a corresponding grade for each module. If there is no official grade yet, an expected one must be entered.</p>
+<h2>Calculating the average grade in the <abbr title="Bachelor of Science">B.&#160;Sc.</abbr> Physics program at <abbr
+    title="Westfälische Wilhelms-Universität">WWU</abbr> Münster</h2>
+<noscript>
+  <p class="fsphys_error"><strong><a href="https://en.wikipedia.org/wiki/JavaScript" class="ext"
+        target="_blank">JavaScript</a> must be activated in your browser in order to use the grade calculator!
+      Unfortunately, no calculations can be executed without JavaScript.</strong></p>
+</noscript>
+<p>With this little tool, the final average grade for the bachelor’s program can be calculated. This can be done by
+  simply entering a corresponding grade for each module. If there is no official grade yet, an expected one must be
+  entered.</p>
 <div id="fsphys_gc_form">
-<p><small>Version: <span id="fsphys_gc_version">2021-05-27</span></small></p>
-<p>PO-Version: 
-	<select id="fsphys_gc_er_version">
-		<option value=20161117 >Since WS 2016/2017</option>
-		<option value=20210412 >Since WS 2020/2021</option>
-	</select>
-</p>
-<table>
-  <colgroup><col style="width: 35%;" /><col /><col /><col style="width: 35%;" /></colgroup>
-  <thead>
-    <tr>
-      <th scope="col">Module</th>
-      <th scope="col">Grade</th>
-      <th scope="col">Weight according to <a href="/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html" class="ext" target="_blank">regulations</a>&#160;(%)</th>
-      <th scope="col">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><label for="fsphys_gc_physics_1">Physics&#160;I</label></td>
-      <td><input id="fsphys_gc_physics_1" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_physics_1_weight" class="fsphys_gc_weight">11</td>
-      <td id=fsphys_gc_physics_hint rowspan="3">From the modules <i>Physics&#160;I–III</i>, only the best two grades are included in the total grade, with a weight of 11&#160;% each.</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_physics_2">Physics&#160;II</label></td>
-      <td><input id="fsphys_gc_physics_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_physics_2_weight" class="fsphys_gc_weight">11</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_physics_3">Physics&#160;III</label></td>
-      <td><input id="fsphys_gc_physics_3" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_physics_3_weight" class="fsphys_gc_weight">0</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_math_2">Fundamental Mathematics<br />
-      (Math for Physicists&#160;II)</label></td>
-      <td><input id="fsphys_gc_math_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_math_2_weight" class="fsphys_gc_weight">11</td>
-      <td id=fsphys_gc_math_hint rowspan="2">Only the best grade from the modules <i>Fundamental Mathematics</i> and <i>Integration Theory</i> enters the total grade with a weight of 11&#160;%. (<i>Math for Physicists&#160;I</i> is not an “exam” according to the regulations, so it counts with 0&#160;%.)</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_math_3">Integration Theory<br />
-      (Math for Physicists&#160;III)</label></td>
-      <td><input id="fsphys_gc_math_3" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_math_3_weight" class="fsphys_gc_weight">0</td>
-    </tr>
-    <tr>
-      <td colspan="3">Interdisciplinary Studies</td>
-      <td  id=fsphys_gc_minor_hint rowspan="5">The grade for the module <i>Interdisciplinary Studies</i> is formed, depending on the subject, as described in the <a href="/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html" class="ext" target="_blank">exam regulations</a>. (The weights for the individual exams have to be entered manually. E.&#160;g. in the case of <i>Computer Science</i>: 50–50.)</td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td><label for="fsphys_gc_minor_1">Exam&#160;1</label></td>
-      <td><input id="fsphys_gc_minor_1" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_1_weight" min="0" max="100" value="50" type="number" /></td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td><label for="fsphys_gc_minor_2">Exam&#160;2</label></td>
-      <td><input id="fsphys_gc_minor_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_2_weight" min="0" max="100" value="50" type="number" /></td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td><label for="fsphys_gc_minor_3">Exam&#160;3</label></td>
-      <td><input id="fsphys_gc_minor_3" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_3_weight" min="0" max="100" value="0" type="number" /></td>
-    </tr>
-    <tr class="fsphys_gc_indent">
-      <td>Total grade – minor</td>
-      <td><output id="fsphys_gc_minor" for="fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight">4.00</output></td>
-      <td id="fsphys_gc_minor_weight" class="fsphys_gc_weight">12</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_quantum_mechanics">Atomic and Quantum Physics</label></td>
-      <td><input id="fsphys_gc_quantum_mechanics" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_quantum_mechanics_weight" class="fsphys_gc_weight">7</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_signal_processing">Measuring Technology and Signal Processing</label></td>
-      <td><input id="fsphys_gc_signal_processing" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_signal_processing_weight" class="fsphys_gc_weight">7</td>
-      <td></td>
-    </tr>
-    <tr>
+  <p><small>Version: <span id="fsphys_gc_version">2021-05-27</span></small></p>
+  <p>PO-Version:
+    <select id="fsphys_gc_er_version">
+      <option value=20161117>Since WS 2016/2017</option>
+      <option value=20210412>Since WS 2020/2021</option>
+    </select>
+  </p>
+  <table>
+    <colgroup>
+      <col style="width: 35%;" />
+      <col />
+      <col />
+      <col style="width: 35%;" />
+    </colgroup>
+    <thead>
+      <tr>
+        <th scope="col">Module</th>
+        <th scope="col">Grade</th>
+        <th scope="col">Weight according to <a href="/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html" class="ext"
+            target="_blank">regulations</a>&#160;(%)</th>
+        <th scope="col">Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><label for="fsphys_gc_physics_1">Physics&#160;I</label></td>
+        <td><input id="fsphys_gc_physics_1" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_physics_1_weight" class="fsphys_gc_weight">11</td>
+        <td id=fsphys_gc_physics_hint rowspan="3">From the modules <i>Physics&#160;I–III</i>, only the best two grades
+          are included in the total grade, with a weight of 11&#160;% each.</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_physics_2">Physics&#160;II</label></td>
+        <td><input id="fsphys_gc_physics_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_physics_2_weight" class="fsphys_gc_weight">11</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_physics_3">Physics&#160;III</label></td>
+        <td><input id="fsphys_gc_physics_3" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_physics_3_weight" class="fsphys_gc_weight">0</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_math_2">Fundamental Mathematics<br />
+            (Math for Physicists&#160;II)</label></td>
+        <td><input id="fsphys_gc_math_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_math_2_weight" class="fsphys_gc_weight">11</td>
+        <td id=fsphys_gc_math_hint rowspan="2">Only the best grade from the modules <i>Fundamental Mathematics</i> and
+          <i>Integration Theory</i> enters the total grade with a weight of 11&#160;%. (<i>Math for
+            Physicists&#160;I</i> is not an “exam” according to the regulations, so it counts with 0&#160;%.)</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_math_3">Integration Theory<br />
+            (Math for Physicists&#160;III)</label></td>
+        <td><input id="fsphys_gc_math_3" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_math_3_weight" class="fsphys_gc_weight">0</td>
+      </tr>
+      <tr>
+        <td colspan="3">Interdisciplinary Studies</td>
+        <td id=fsphys_gc_minor_hint rowspan="5">The grade for the module <i>Interdisciplinary Studies</i> is formed,
+          depending on the subject, as described in the <a href="/Physik/en/Studieren/Studiengaenge/InfoPhBSc.html"
+            class="ext" target="_blank">exam regulations</a>. (The weights for the individual exams have to be entered
+          manually. E.&#160;g. in the case of <i>Computer Science</i>: 50–50.)</td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td><label for="fsphys_gc_minor_1">Exam&#160;1</label></td>
+        <td><input id="fsphys_gc_minor_1" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_1_weight" min="0" max="100" value="50" type="number" />
+        </td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td><label for="fsphys_gc_minor_2">Exam&#160;2</label></td>
+        <td><input id="fsphys_gc_minor_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_2_weight" min="0" max="100" value="50" type="number" />
+        </td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td><label for="fsphys_gc_minor_3">Exam&#160;3</label></td>
+        <td><input id="fsphys_gc_minor_3" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td class="fsphys_gc_weight"><input id="fsphys_gc_minor_3_weight" min="0" max="100" value="0" type="number" />
+        </td>
+      </tr>
+      <tr class="fsphys_gc_indent">
+        <td>Total grade – minor</td>
+        <td><output id="fsphys_gc_minor"
+            for="fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight">4.00</output>
+        </td>
+        <td id="fsphys_gc_minor_weight" class="fsphys_gc_weight">12</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_quantum_mechanics">Atomic and Quantum Physics</label></td>
+        <td><input id="fsphys_gc_quantum_mechanics" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_quantum_mechanics_weight" class="fsphys_gc_weight">7</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_signal_processing">Measuring Technology and Signal Processing</label></td>
+        <td><input id="fsphys_gc_signal_processing" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_signal_processing_weight" class="fsphys_gc_weight">7</td>
+        <td></td>
+      </tr>
+      <tr>
         <td><label for=fsphys_gc_computational_physics>Computational Physics</label></td>
         <td><input id=fsphys_gc_computational_physics type=number min=1 max=4 step=0.1 value=4></td>
         <td id=fsphys_gc_computational_physics_weight class=fsphys_gc_weight>7</td>
         <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_structure_of_matter">Structure of Matter</label></td>
-      <td><input id="fsphys_gc_structure_of_matter" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_structure_of_matter_weight" class="fsphys_gc_weight">12</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for=fsphys_gc_lab_course_1>Laboratory Course&#160;I</label></td>
-      <td><input id=fsphys_gc_lab_course_1 type=number min=1 max=4 step=0.1 value=4></td>
-      <td id=fsphys_gc_lab_course_1_weight class=fsphys_gc_weight>9</td>
-      <td id=fsphys_gc_lab_course_hint rowspan="2">The <i>Laboratory Course&#160;I</i> does not enter into the total grade.</td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_lab_course_2">Laboratory Course&#160;II</label></td>
-      <td><input id="fsphys_gc_lab_course_2" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_lab_course_2_weight" class="fsphys_gc_weight">9</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_statistical_physics">Quantum Theory and Statistical Physics</label></td>
-      <td><input id="fsphys_gc_statistical_physics" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_statistical_physics_weight" class="fsphys_gc_weight">10</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><label for="fsphys_gc_bachelor_thesis">Bachelor’s thesis</label></td>
-      <td><input id="fsphys_gc_bachelor_thesis" min="1" max="4" step="0.1" value="4" type="number" /></td>
-      <td id="fsphys_gc_bachelor_thesis_weight" class="fsphys_gc_weight">10</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
-<p style="font-size: larger;"><strong>Total bachelor’s grade:&#160;<output id="fsphys_gc_total" for="fsphys_gc_physics_1 fsphys_gc_physics_2 fsphys_gc_physics_3 fsphys_gc_math_2 fsphys_gc_math_3 fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight fsphys_gc_quantum_mechanics fsphys_gc_signal_processing fsphys_gc_structure_of_matter fsphys_gc_lab_course_2 fsphys_gc_statistical_physics fsphys_gc_bachelor_thesis">4.00</output></strong></p>
-<p>By clicking the following button, you can “save” your entered data to the <a href="https://en.wikipedia.org/wiki/URL" class="ext" target="_blank">URL</a>. In order to load the data later on, you have to save the URL somewhere – for example, you can set a bookmark after clicking the button.</p>
-<p><small>Once again, we’d like to emphasize that all data remains on your device. The data are saved within the <a href="https://en.wikipedia.org/wiki/Fragment_identifier" class="ext" target="_blank">URL fragment</a> which is never transmitted by the browser to the opened website.</small></p>
-<button id="fsphys_gc_save">Save data (⇒ bookmark can be set then!)</button></div>
-<script type="text/javascript">let FSPHYS_LOCALE = 'en-US';</script> <script type="text/javascript" src="/Physik.FSPHYS/js/grade_calculator.js"></script>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_structure_of_matter">Structure of Matter</label></td>
+        <td><input id="fsphys_gc_structure_of_matter" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_structure_of_matter_weight" class="fsphys_gc_weight">12</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for=fsphys_gc_lab_course_1>Laboratory Course&#160;I</label></td>
+        <td><input id=fsphys_gc_lab_course_1 type=number min=1 max=4 step=0.1 value=4></td>
+        <td id=fsphys_gc_lab_course_1_weight class=fsphys_gc_weight>9</td>
+        <td id=fsphys_gc_lab_course_hint rowspan="2">The <i>Laboratory Course&#160;I</i> does not enter into the total
+          grade.</td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_lab_course_2">Laboratory Course&#160;II</label></td>
+        <td><input id="fsphys_gc_lab_course_2" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_lab_course_2_weight" class="fsphys_gc_weight">9</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_statistical_physics">Quantum Theory and Statistical Physics</label></td>
+        <td><input id="fsphys_gc_statistical_physics" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_statistical_physics_weight" class="fsphys_gc_weight">10</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><label for="fsphys_gc_bachelor_thesis">Bachelor’s thesis</label></td>
+        <td><input id="fsphys_gc_bachelor_thesis" min="1" max="4" step="0.1" value="0" type="number" /></td>
+        <td id="fsphys_gc_bachelor_thesis_weight" class="fsphys_gc_weight">10</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <p style="font-size: larger;"><strong>Total bachelor’s grade:&#160;<output id="fsphys_gc_total"
+        for="fsphys_gc_physics_1 fsphys_gc_physics_2 fsphys_gc_physics_3 fsphys_gc_math_2 fsphys_gc_math_3 fsphys_gc_minor_1 fsphys_gc_minor_2 fsphys_gc_minor_3 fsphys_gc_minor_1_weight fsphys_gc_minor_2_weight fsphys_gc_minor_3_weight fsphys_gc_quantum_mechanics fsphys_gc_signal_processing fsphys_gc_structure_of_matter fsphys_gc_lab_course_2 fsphys_gc_statistical_physics fsphys_gc_bachelor_thesis">4.00</output></strong>
+  </p>
+  <p>By clicking the following button, you can “save” your entered data to the <a
+      href="https://en.wikipedia.org/wiki/URL" class="ext" target="_blank">URL</a>. In order to load the data later on,
+    you have to save the URL somewhere – for example, you can set a bookmark after clicking the button.</p>
+  <p><small>Once again, we’d like to emphasize that all data remains on your device. The data are saved within the <a
+        href="https://en.wikipedia.org/wiki/Fragment_identifier" class="ext" target="_blank">URL fragment</a> which is
+      never transmitted by the browser to the opened website.</small></p>
+  <button id="fsphys_gc_save">Save data (⇒ bookmark can be set then!)</button>
+</div>
+<script type="text/javascript">let FSPHYS_LOCALE = 'en-US';</script>
+<script type="text/javascript" src="/Physik.FSPHYS/js/grade_calculator.js"></script>


### PR DESCRIPTION
Dies ist eine Implementierung zu Issue #6, sodass die Gesamtnote eine Mittelung aller angebenen (d.h. != Null) Noten ist.

Mein Editor hat die HTMLs automatisch umformatiert, pardon.
Die einzige Änderung ist value="4" zu value="0" in allen Notenfeldern.